### PR TITLE
Fix Java distribution on MacOS ARM64

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -55,7 +55,8 @@ jobs:
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@a18c333f3f14249953dab3e186e5e21bf3390f1d # v3.5.1
       with:
-        distribution: 'temurin'
+        # There is no Temurin version for MacOS on ARM64
+        distribution: ${{ runner.os == 'macos-latest' && 'zulu' || 'temurin' }}
         java-version: ${{ matrix.java }}
     - name: Build with Maven
       run: mvn --errors --show-version --batch-mode --no-transfer-progress install -D"maven.javadoc.skip=true" -D"org.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn"


### PR DESCRIPTION
Since Temurin does not have an ARM64 version of JDK 8, we can use Zulu on MacOS.