### PR TITLE
Only run CI on `master` branch

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,12 @@
 
 name: Java CI
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Currently, the CI is configured to run on all the branches of this repository. For PRs from other branches (like those created by Dependabot), this means that the CI runs twice.

This change limits CI builds to the `master` branch.